### PR TITLE
Add missing include to fix build on Fedora 42

### DIFF
--- a/libfive/include/libfive/tree/tree.hpp
+++ b/libfive/include/libfive/tree/tree.hpp
@@ -16,6 +16,7 @@ You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <utility>
 #include <variant>
 #include <vector>
+#include <cstdint>
 
 #include "libfive/tree/opcode.hpp"
 #include "libfive/tree/operations.hpp"


### PR DESCRIPTION
I'm currently working on the build of PythonSCAD on various platforms.
PythonSCAD uses libfive as a gitsubmodule in `submodules/libfive` and during build, cmake tries to build it.

On Ubuntu 25.04 it works without issues, but I've just installed Fedora 42 in a VM and the build fails with this error:

```plaintext
[  6%] Building CXX object submodules/libfive/libfive/src/CMakeFiles/libfive.dir/render/brep/dc/dc_tree3.cpp.o
In file included from /usr/lib/gcc/x86_64-redhat-linux/15/include/immintrin.h:43,
                 from /usr/include/eigen3/Eigen/src/Core/util/ConfigureVectorization.h:361,
                 from /usr/include/eigen3/Eigen/Core:22,
                 from /usr/include/eigen3/Eigen/StdVector:14,
                 from /home/fedora/coding/pythonscad/submodules/libfive/libfive/src/render/brep/dc/dc_tree.inl:17,
                 from /home/fedora/coding/pythonscad/submodules/libfive/libfive/src/render/brep/dc/dc_tree3.cpp:10:
In function ‘__m256d _mm256_loadu_pd(const double*)’,
    inlined from ‘Packet Eigen::internal::ploadu(const typename unpacket_traits<T>::type*) [with Packet = __vector(4) double]’ at /usr/include/eigen3/Eigen/src/Core/arch/AVX/PacketMath.h:582:129,
    inlined from ‘Packet Eigen::internal::ploadt(const typename unpacket_traits<T>::type*) [with Packet = __vector(4) double; int Alignment = 0]’ at /usr/include/eigen3/Eigen/src/Core/GenericPacketMath.h:969:26,
    inlined from ‘PacketType Eigen::internal::evaluator<Eigen::PlainObjectBase<Derived> >::packet(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = __vector(4) double; Derived = Eigen::Matrix<double, 3, 1>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:238:42,
    inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignPacket(Eigen::Index, Eigen::Index) [with int StoreMode = 32; int LoadMode = 0; PacketType = __vector(4) double; DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >; Functor = Eigen::internal::assign_op<double, double>; int Version = 0]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:675:116,
    inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignPacketByOuterInner(Eigen::Index, Eigen::Index) [with int StoreMode = 32; int LoadMode = 0; PacketType = __vector(4) double; DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >; Functor = Eigen::internal::assign_op<double, double>; int Version = 0]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:689:48,
    inlined from ‘static void Eigen::internal::dense_assignment_loop<Kernel, 4, 0>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false> >, Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >, Eigen::internal::assign_op<double, double>, 0>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:572:86,
    inlined from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false>; SrcXprType = Eigen::Matrix<double, 3, 1>; Functor = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:785:37,
    inlined from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false>; SrcXprType = Eigen::Matrix<double, 3, 1>; Functor = Eigen::internal::assign_op<double, double>; Weak = void]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:954:31,
    inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false>; Src = Eigen::Matrix<double, 3, 1>; Func = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename enable_if<(! evaluator_assume_aliasing<Src>::value), void*>::type) [with Dst = Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false>; Src = Eigen::Matrix<double, 3, 1>; Func = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:858:27,
    inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false>; Src = Eigen::Matrix<double, 3, 1>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:836:18,
    inlined from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Matrix<double, 3, 1>; Derived = Eigen::Block<Eigen::Matrix<double, 4, 1>, -1, -1, false>]’ at /usr/include/eigen3/Eigen/src/Core/Assign.h:66:28,
    inlined from ‘Eigen::CommaInitializer<MatrixType>::CommaInitializer(XprType&, const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Matrix<double, 3, 1>; XprType = Eigen::Matrix<double, 4, 1>]’ at /usr/include/eigen3/Eigen/src/Core/CommaInitializer.h:48:51,
    inlined from ‘Eigen::CommaInitializer<Derived> Eigen::DenseBase<Derived>::operator<<(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Matrix<double, 3, 1>; Derived = Eigen::Matrix<double, 4, 1>]’ at /usr/include/eigen3/Eigen/src/Core/CommaInitializer.h:159:72,
    inlined from ‘void libfive::Intersection<N>::push(Eigen::Matrix<double, N, 1>, Eigen::Matrix<double, N, 1>, double) [with unsigned int N = 3]’ at /home/fedora/coding/pythonscad/submodules/libfive/libfive/src/../include/libfive/render/brep/dc/intersection.hpp:37:12,
    inlined from ‘void libfive::DCTree<N>::saveIntersection(const Vec&, const Vec&, double, size_t, Pool&) [with unsigned int N = 3]’ at /home/fedora/coding/pythonscad/submodules/libfive/libfive/src/render/brep/dc/dc_tree.inl:564:42:
/usr/lib/gcc/x86_64-redhat-linux/15/include/avxintrin.h:837:24: warning: array subscript ‘__m256d_u[0]’ is partly outside array bounds of ‘Eigen::Matrix<double, 3, 1> [1]’ [-Warray-bounds=]
  837 |   return *(__m256d_u *)__P;
      |                        ^~~
/home/fedora/coding/pythonscad/submodules/libfive/libfive/src/render/brep/dc/dc_tree.inl: In member function ‘void libfive::DCTree<N>::saveIntersection(const Vec&, const Vec&, double, size_t, Pool&) [with unsigned int N = 3]’:
/home/fedora/coding/pythonscad/submodules/libfive/libfive/src/render/brep/dc/dc_tree.inl:564:42: note: at offset [0, 16] into object ‘<anonymous>’ of size 24
  564 |     this->leaf->intersections[edge]->push(pos, derivs, value);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```

Following the recommendation of gcc, I've added the include as contained in this PR and with that the build works.